### PR TITLE
Return opcode fix

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -515,7 +515,7 @@ local function luau_load(module, env)
 					local nresults
 
 					if b == LUA_MULTRET then
-						nresults = top - A + 1
+						nresults = top
 					else
 						nresults = B - 1
 					end


### PR DESCRIPTION
Return opcode would fail on the [assert.lua](https://github.com/luau-lang/luau/blob/master/tests/conformance/assert.lua) test, because the return from the "ecall" function would return nil.  
It now passes this test with this new change, by simply set the top variable when we are returning multiple values.
This patch lines up with the LuaU source code on [this line](https://github.com/luau-lang/luau/blob/f31232d301e9b738fca366a7924adad94ab18f27/VM/src/lvmexecute.cpp#L1018). 