### PR TITLE
Optimizations and Refractoring

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -1,229 +1,281 @@
 local FIU_DEBUGGING = true
 
---// Some functions dont have a builtin so its faster to make them locally accessible, error and string.format don't need them since they stop execution
-local table_pack = table.pack 
+-- // Some functions dont have a builtin so its faster to make them locally accessible, error and string.format don't need them since they stop execution
+local table_pack = table.pack
 local table_create = table.create
 local table_move = table.move
-local coroutine_create = coroutine.create 
-local coroutine_yield = coroutine.yield 
-local coroutine_resume = coroutine.resume
-local to_number = tonumber
-local protected_call = pcall
 
---[[
-NOP/REMOVED - 0
-A - 1
-AB - 2
-ABC - 3
-AD - 4
-AE - 5 
-true - has aux data
-]]
-local op_list = {
-	{ "NOP", 0 },
-	{ "BREAK", 0 },
-	{ "LOADNIL", 1 },
-	{ "LOADB", 3 },
-	{ "LOADN", 4 },
-	{ "LOADK", 4 },
-	{ "MOVE", 2 },
-	{ "GETGLOBAL", 1, true },
-	{ "SETGLOBAL", 1, true },
-	{ "GETUPVAL", 2 },
-	{ "SETUPVAL", 2 },
-	{ "CLOSEUPVALS", 1 },
-	{ "GETIMPORT", 4, true },
-	{ "GETTABLE", 3 },
-	{ "SETTABLE", 3 },
-	{ "GETTABLEKS", 3, true },
-	{ "SETTABLEKS", 3, true },
-	{ "GETTABLEN", 3 },
-	{ "SETTABLEN", 3 },
-	{ "NEWCLOSURE", 4 },
-	{ "NAMECALL", 3, true },
-	{ "CALL", 3 },
-	{ "RETURN", 2 },
-	{ "JUMP", 4 },
-	{ "JUMPBACK", 4 },
-	{ "JUMPIF", 4 },
-	{ "JUMPIFNOT", 4 },
-	{ "JUMPIFEQ", 4, true },
-	{ "JUMPIFLE", 4, true },
-	{ "JUMPIFLT", 4, true },
-	{ "JUMPIFNOTEQ", 4, true },
-	{ "JUMPIFNOTLE", 4, true },
-	{ "JUMPIFNOTLT", 4, true },
-	{ "ADD", 3 },
-	{ "SUB", 3 },
-	{ "MUL", 3 },
-	{ "DIV", 3 },
-	{ "MOD", 3 },
-	{ "POW", 3 },
-	{ "ADDK", 3 },
-	{ "SUBK", 3 },
-	{ "MULK", 3 },
-	{ "DIVK", 3 },
-	{ "MODK", 3 },
-	{ "POWK", 3 },
-	{ "AND", 3 },
-	{ "OR", 3 },
-	{ "ANDK", 3 },
-	{ "ORK", 3 },
-	{ "CONCAT", 3 },
-	{ "NOT", 2 },
-	{ "MINUS", 2 },
-	{ "LENGTH", 2 },
-	{ "NEWTABLE", 2, true },
-	{ "DUPTABLE", 4 },
-	{ "SETLIST", 3, true },
-	{ "FORNPREP", 4 },
-	{ "FORNLOOP", 4 },
-	{ "FORGLOOP", 4, true },
-	{ "FORGPREP_INEXT", 4 },
-	{ "LOP_DEP_FORGLOOP_INEXT", 0 },
-	{ "FORGPREP_NEXT", 4 },
-	{ "LOP_DEP_FORGLOOP_NEXT", 0 },
-	{ "GETVARARGS", 2 },
-	{ "DUPCLOSURE", 4 },
-	{ "PREPVARARGS", 1 },
-	{ "LOADKX", 1, true },
-	{ "JUMPX", 5 },
-	{ "FASTCALL", 3 },
-	{ "COVERAGE", 5 },
-	{ "CAPTURE", 2 },
-	{ "SUBRK", 3 }, --// Previously DEP_JUMPIFEQK
-	{ "DIVRK", 3 }, --// Previously DEP_JUMPIFNOTEQK
-	{ "FASTCALL1", 3 },
-	{ "FASTCALL2", 3, true },
-	{ "FASTCALL2K", 3, true },
-	{ "FORGPREP", 4 },
-	{ "JUMPXEQKNIL", 4, true },
-	{ "JUMPXEQKB", 4, true },
-	{ "JUMPXEQKN", 4, true },
-	{ "JUMPXEQKS", 4, true },
-	{ "IDIV", 3 },
-	{ "IDIVK", 3 },
+local coroutine_create = coroutine.create
+local coroutine_yield = coroutine.yield
+local coroutine_resume = coroutine.resume
+
+local tonumber = tonumber
+local pcall = pcall
+
+local buffer_fromstring = buffer.fromstring
+local buffer_readu8 = buffer.readu8
+local buffer_readu32 = buffer.readu32
+local buffer_readstring = buffer.readstring
+local buffer_readf64 = buffer.readf64
+
+-- // opList contains information about the instruction, each instruction is defined in this format:
+-- // {OP_NAME, OP_MODE, K_MODE, HAS_AUX}
+-- // OP_MODE specifies what type of registers the instruction uses if any
+--		0 = NONE
+--		1 = A
+--		2 = AB
+--		3 = ABC
+--		4 = AD
+--		5 = AE
+-- // K_MODE specifies if the instruction has a register that holds a constant table index, which will be directly converted to the constant in the 2nd pass
+--		0 = NONE
+--		1 = AUX
+--		2 = C
+--		3 = D
+--		4 = AUX import
+--		5 = AUX boolean low 1 bit
+--		6 = AUX number low 24 bits
+-- // HAS_AUX boolean specifies whether the instruction is followed up with an AUX word, which may be used to execute the instruction.
+
+local opList = {
+	{ "NOP", 0, 0, false },
+	{ "BREAK", 0, 0, false },
+	{ "LOADNIL", 1, 0, false },
+	{ "LOADB", 3, 0, false },
+	{ "LOADN", 4, 0, false },
+	{ "LOADK", 4, 3, false },
+	{ "MOVE", 2, 0, false },
+	{ "GETGLOBAL", 1, 1, true },
+	{ "SETGLOBAL", 1, 1, true },
+	{ "GETUPVAL", 2, 0, false },
+	{ "SETUPVAL", 2, 0, false },
+	{ "CLOSEUPVALS", 1, 0, false },
+	{ "GETIMPORT", 4, 4, true },
+	{ "GETTABLE", 3, 0, false },
+	{ "SETTABLE", 3, 0, false },
+	{ "GETTABLEKS", 3, 1, true },
+	{ "SETTABLEKS", 3, 1, true },
+	{ "GETTABLEN", 3, 0, false },
+	{ "SETTABLEN", 3, 0, false },
+	{ "NEWCLOSURE", 4, 0, false },
+	{ "NAMECALL", 3, 1, true },
+	{ "CALL", 3, 0, false },
+	{ "RETURN", 2, 0, false },
+	{ "JUMP", 4, 0, false },
+	{ "JUMPBACK", 4, 0, false },
+	{ "JUMPIF", 4, 0, false },
+	{ "JUMPIFNOT", 4, 0, false },
+	{ "JUMPIFEQ", 4, 0, true },
+	{ "JUMPIFLE", 4, 0, true },
+	{ "JUMPIFLT", 4, 0, true },
+	{ "JUMPIFNOTEQ", 4, 0, true },
+	{ "JUMPIFNOTLE", 4, 0, true },
+	{ "JUMPIFNOTLT", 4, 0, true },
+	{ "ADD", 3, 0, false },
+	{ "SUB", 3, 0, false },
+	{ "MUL", 3, 0, false },
+	{ "DIV", 3, 0, false },
+	{ "MOD", 3, 0, false },
+	{ "POW", 3, 0, false },
+	{ "ADDK", 3, 2, false },
+	{ "SUBK", 3, 2, false },
+	{ "MULK", 3, 2, false },
+	{ "DIVK", 3, 2, false },
+	{ "MODK", 3, 2, false },
+	{ "POWK", 3, 2, false },
+	{ "AND", 3, 0, false },
+	{ "OR", 3, 0, false },
+	{ "ANDK", 3, 2, false },
+	{ "ORK", 3, 2, false },
+	{ "CONCAT", 3, 0, false },
+	{ "NOT", 2, 0, false },
+	{ "MINUS", 2, 0, false },
+	{ "LENGTH", 2, 0, false },
+	{ "NEWTABLE", 2, 0, true },
+	{ "DUPTABLE", 4, 3, false },
+	{ "SETLIST", 3, 0, true },
+	{ "FORNPREP", 4, 0, false },
+	{ "FORNLOOP", 4, 0, false },
+	{ "FORGLOOP", 4, 0, true },
+	{ "FORGPREP_INEXT", 4, 0, false },
+	{ "DEP_FORGLOOP_INEXT", 0, 0, false },
+	{ "FORGPREP_NEXT", 4, 0, false },
+	{ "DEP_FORGLOOP_NEXT", 0, 0, false },
+	{ "GETVARARGS", 2, 0, false },
+	{ "DUPCLOSURE", 4, 3, false },
+	{ "PREPVARARGS", 1, 0, false },
+	{ "LOADKX", 1, 1, true },
+	{ "JUMPX", 5, 0, false },
+	{ "FASTCALL", 3, 0, false },
+	{ "COVERAGE", 5, 0, false },
+	{ "CAPTURE", 2, 0, false },
+	{ "SUBRK", 3, 2, false },
+	{ "DIVRK", 3, 2, false },
+	{ "FASTCALL1", 3, 0, false },
+	{ "FASTCALL2", 3, 0, true },
+	{ "FASTCALL2K", 3, 1, true },
+	{ "FORGPREP", 4, 0, false },
+	{ "JUMPXEQKNIL", 4, 5, true },
+	{ "JUMPXEQKB", 4, 5, true },
+	{ "JUMPXEQKN", 4, 6, true },
+	{ "JUMPXEQKS", 4, 6, true },
+	{ "IDIV", 3, 0, false },
+	{ "IDIVK", 3, 2, false },
 }
 
 local LUA_MULTRET = -1
 local LUA_GENERALIZED_TERMINATOR = -2
 local function luau_deserialize(bytecode)
-	local stream = buffer.fromstring(bytecode)
+	local stream = buffer_fromstring(bytecode)
 	local position = 0
 
-	local function read_byte()
-		local b = buffer.readu8(stream, position)
+	local function readByte()
+		local byte = buffer_readu8(stream, position)
 		position = position + 1
-		return b
+		return byte
 	end
 
-	local function read_integer()
-		local int = buffer.readu32(stream, position)
+	local function readWord()
+		local word = buffer_readu32(stream, position)
 		position = position + 4
-		return int
+		return word
 	end
 
-	local function read_varint()
+	local function readVarint()
 		local result = 0
+
 		for i = 0, 4 do
-			local value = read_byte()
+			local value = readByte()
 			result = bit32.bor(result, bit32.lshift(bit32.band(value, 0x7F), i * 7))
-			if bit32.band(value, 0x80) == 0 then
+			if not bit32.btest(value, 0x80) then
 				break
 			end
 		end
+
 		return result
 	end
 
-	local function read_string()
-		local size = read_varint()
-		local str
+	local function readString()
+		local size = readVarint()
+
 		if size == 0 then
 			return ""
 		else
-			str = buffer.readstring(stream, position, size)
+			local str = buffer_readstring(stream, position, size)
 			position = position + size
+
+			return str
 		end
-		return str
 	end
 
-	local luauVersion = read_byte()
+	local luauVersion = readByte()
 	local typesversion = 0
 	if luauVersion == 0 then 
-		error("The bytecode that was passed was an error message!", 0)
+		error("The bytecode that was passed was an error message!",0)
 	elseif luauVersion < 3 or luauVersion > 5 then
-		error("Unsupported bytecode provided!", 0)
+		error("Unsupported bytecode provided!",0)
 	elseif luauVersion >= 4 then
-		typesversion = read_byte()
+		typesversion = readByte()
 	end
 
-	local stringCount = read_varint()
-	local stringList = table.create(stringCount)
+	local stringCount = readVarint()
+	local stringList = table_create(stringCount)
 
 	for i = 1, stringCount do
-		stringList[i] = read_string()
+		stringList[i] = readString()
 	end
 
-	local function read_instruction(codelist)
-		local i = {}
-
-		local value = read_integer()
+	local function readInstruction(codeList)
+		local value = readWord()
 		local opcode = bit32.band(value, 0xFF)
-		i.value = value
-		i.opcode = opcode
 
-		local info = op_list[opcode + 1]
-		i.opname = info[1]
+		local opInfo = opList[opcode + 1]
+		local opName = opInfo[1]
+		local opMode = opInfo[2]
+		local kMode = opInfo[3]
+		local usesAUX = opInfo[4]
 
-		local optype = info[2]
-		i.type = optype
+		local inst = {
+			code = opcode;
+			name = opName;
+			opMode = opMode;
+			kMode = kMode;
+		}
 
-		if optype == 3 then --[[ ABC ]]
-			i.A = bit32.band(bit32.rshift(value, 8), 0xFF)
-			i.B = bit32.band(bit32.rshift(value, 16), 0xFF)
-			i.C = bit32.band(bit32.rshift(value, 24), 0xFF)
-		elseif optype == 2 then --[[ AB ]]
-			i.A = bit32.band(bit32.rshift(value, 8), 0xFF)
-			i.B = bit32.band(bit32.rshift(value, 16), 0xFF)
-		elseif optype == 1 then --[[ A ]]
-			i.A = bit32.band(bit32.rshift(value, 8), 0xFF)
-		elseif optype == 4 then --[[ AD ]]
-			i.A = bit32.band(bit32.rshift(value, 8), 0xFF)
+		table.insert(codeList, inst)
+
+		if opMode == 1 then --[[ A ]]
+			inst.A = bit32.band(bit32.rshift(value, 8), 0xFF)
+		elseif opMode == 2 then --[[ AB ]]
+			inst.A = bit32.band(bit32.rshift(value, 8), 0xFF)
+			inst.B = bit32.band(bit32.rshift(value, 16), 0xFF)
+		elseif opMode == 3 then --[[ ABC ]]
+			inst.A = bit32.band(bit32.rshift(value, 8), 0xFF)
+			inst.B = bit32.band(bit32.rshift(value, 16), 0xFF)
+			inst.C = bit32.band(bit32.rshift(value, 24), 0xFF)
+		elseif opMode == 4 then --[[ AD ]]
+			inst.A = bit32.band(bit32.rshift(value, 8), 0xFF)
 			local temp = bit32.band(bit32.rshift(value, 16), 0xFFFF)
-			i.D = if temp < 0x8000 then temp else temp - 0x10000
-		elseif optype == 5 then --[[ AE ]]
+			inst.D = if temp < 0x8000 then temp else temp - 0x10000
+		elseif opMode == 5 then --[[ AE ]]
 			local temp = bit32.band(bit32.rshift(value, 8), 0xFFFFFF)
-			i.E = if temp < 0x800000 then temp else temp - 0x1000000
+			inst.E = if temp < 0x800000 then temp else temp - 0x1000000
 		end
 
-		local uses_aux = info[3]
-		if uses_aux then 
-			local aux = read_integer()
-			i.aux = aux
+		if usesAUX then 
+			local aux = readWord()
+			inst.aux = aux
 
-			table.insert(codelist, i)
-			table.insert(codelist, {value = aux}) --// Includes data in list to not break jumps, loops, etc
-
-			return true
+			table.insert(codeList, {value = aux})
 		end
 
-		table.insert(codelist, i)
-
-		return false
+		return usesAUX
 	end
 
-	local function read_proto(bytecodeid)
-		local maxstacksize = read_byte()
-		local numparams = read_byte()
-		local nups = read_byte()
-		local isvararg = read_byte() ~= 0
+	local function checkKMode(inst, k)
+		local kMode = inst.kMode
+
+		if kMode == 1 then --// AUX
+			inst.K = k[inst.aux +  1]
+		elseif kMode == 2 then --// C
+			inst.K = k[inst.C + 1]
+		elseif kMode == 3 then--// D
+			inst.K = k[inst.D + 1]
+		elseif kMode == 4 then --// AUX import
+			local extend = inst.aux
+
+			local count = bit32.rshift(extend, 30)
+			local id0 = bit32.band(bit32.rshift(extend, 20), 0x3FF)
+			inst.K0 = k[id0 + 1]
+
+			if count == 2 then
+				local id1 = bit32.band(bit32.rshift(extend, 10), 0x3FF)
+				inst.K1 = k[id1 + 1]
+			elseif count == 3 then
+				local id1 = bit32.band(bit32.rshift(extend, 10), 0x3FF)
+				local id2 = bit32.band(bit32.rshift(extend, 0), 0x3FF)
+				inst.K1 = k[id1 + 1]
+				inst.K2 = k[id2 + 1]
+			end
+		elseif kMode == 5 then --// AUX boolean low 1 bit
+			inst.K = bit32.extract(inst.aux, 0, 1) == 1
+		elseif kMode == 6 then --// AUX number low 24 bits
+			inst.K = k[bit32.extract(inst.aux, 0, 24) + 1]
+		end
+	end
+
+	local function readProto(bytecodeid)
+		local maxstacksize = readByte()
+		local numparams = readByte()
+		local nups = readByte()
+		local isvararg = readByte() ~= 0
 
 		if luauVersion >= 4 then
-			read_byte() --// flags 
+			readByte() --// flags 
 		end
 
-		local sizecode = read_varint()
-		local codelist = table.create(sizecode)
+		local sizecode = readVarint()
+		local codelist = table_create(sizecode)
 
 		local skipnext = false 
 		for i = 1, sizecode do
@@ -232,74 +284,79 @@ local function luau_deserialize(bytecode)
 				continue 
 			end
 
-			skipnext = read_instruction(codelist)
+			skipnext = readInstruction(codelist)
 		end
 
-		local sizek = read_varint()
-		local klist = table.create(sizek)
+		local sizek = readVarint()
+		local klist = table_create(sizek)
 
 		for i = 1, sizek do
-			local kt = read_byte()
+			local kt = readByte()
 			local k
 
 			if kt == 0 then --// Nil
 				k = nil
 			elseif kt == 1 then --// Bool
-				k = read_byte() ~= 0
+				k = readByte() ~= 0
 			elseif kt == 2 then --// Number
-				local d = buffer.readf64(stream, position)
+				local d = buffer_readf64(stream, position)
 				position = position + 8
 				k = d
 			elseif kt == 3 then --// String
-				k = stringList[read_varint()]
+				k = stringList[readVarint()]
 			elseif kt == 4 then --// Import
-				k = read_integer()
+				k = readWord()
 			elseif kt == 5 then --// Table
-				local dataLength = read_varint()
-				local data = table.create(dataLength)
+				local dataLength = readVarint()
+				local data = table_create(dataLength)
 				for i = 1, dataLength do
-					data[i] = read_varint()
+					data[i] = readVarint()
 				end
 				k = data
 			elseif kt == 6 then --// Closure
-				k = read_varint()
+				k = readVarint()
 			elseif kt == 7 then --// Vector
-				error("Fiu does not currently support vector constants!", 0)
+				error("Fiu does not currently support vector constants!",0)
 			end
 
 			klist[i] = k
 		end
-
-		local sizep = read_varint()
-		local protolist = table.create(sizep)
-
-		for i = 1, sizep do
-			protolist[i] = read_varint()
+		
+		-- // 2nd pass to add constant references in the instruction
+		for i = 1, sizecode do
+			checkKMode(codelist[i], klist)
 		end
 
-		local linedefined = read_varint()
-		local debugname = stringList[read_varint()]
+		local sizep = readVarint()
+		local protolist = table_create(sizep)
+
+		for i = 1, sizep do
+			protolist[i] = readVarint()
+		end
+
+		local linedefined = readVarint()
+		local debugname = stringList[readVarint()]
 
 		-- // lineinfo
-		if read_byte() ~= 0 then
-			local lineGap = read_byte()
+		if readByte() ~= 0 then
+			local lineGap = readByte()
 			for i = 1, sizecode do
-				read_byte()
+				readByte()
 			end
 			local intervals = bit32.rshift(sizecode - 1, lineGap) + 1
 			for i = 1, intervals do
-				read_integer()
+				readWord()
 			end
 		end
 
 		-- // debuginfo
-		if read_byte() ~= 0 then
-			local sizel = read_varint()
+		if readByte() ~= 0 then
+			local sizel = readVarint()
 			for i = 1, sizel do
-				read_varint()
-				read_varint()
-				read_varint()
-				read_byte()
+				readVarint()
+				readVarint()
+				readVarint()
+				readByte()
 			end
 		end
 
@@ -324,14 +381,14 @@ local function luau_deserialize(bytecode)
 		}
 	end
 
-	local protoCount = read_varint()
-	local prototypeList = table.create(protoCount)
+	local protoCount = readVarint()
+	local prototypeList = table_create(protoCount)
 
 	for i = 1, protoCount do
-		prototypeList[i] = read_proto(i - 1)
+		prototypeList[i] = readProto(i - 1)
 	end
 
-	local mainp = read_varint()
+	local mainp = readVarint()
 
 	assert(position == #bytecode, "Deserializer position mismatch")
 
@@ -359,7 +416,7 @@ local function luau_load(module, env)
 
 			while true do
 				local inst = code[pc]
-				local op = inst.opcode
+				local op = inst.code
 				pc += 1
 				debugging.pc = pc
 				debugging.name = inst.opname
@@ -372,18 +429,18 @@ local function luau_load(module, env)
 				elseif op == 4 then --[[ LOADN ]]
 					stack[inst.A] = inst.D
 				elseif op == 5 then --[[ LOADK ]]
-					stack[inst.A] = constants[inst.D + 1]
+					stack[inst.A] = inst.K
 				elseif op == 6 then --[[ MOVE ]]
 					stack[inst.A] = stack[inst.B]
 				elseif op == 7 then --[[ GETGLOBAL ]]
 					pc += 1
 
-					local kv = constants[inst.aux + 1]
+					local kv = inst.K
 					stack[inst.A] = env[kv]
 				elseif op == 8 then --[[ SETGLOBAL ]]
 					pc += 1 --// adjust for aux 
 
-					local kv = constants[inst.aux + 1]
+					local kv = inst.K
 					env[kv] = stack[inst.A]
 				elseif op == 9 then --[[ GETUPVAL ]]
 					local uv = upvals[inst.B + 1]
@@ -406,16 +463,12 @@ local function luau_load(module, env)
 					local extend = inst.aux
 
 					local count = bit32.rshift(extend, 30)
-					local id0 = bit32.band(bit32.rshift(extend, 20), 0x3FF)
 					if count == 1 then
-						stack[inst.A] = env[constants[id0 + 1]]
+						stack[inst.A] = env[inst.K0]
 					elseif count == 2 then
-						local id1 = bit32.band(bit32.rshift(extend, 10), 0x3FF)
-						stack[inst.A] = env[constants[id0 + 1]][constants[id1 + 1]]
+						stack[inst.A] = env[inst.K0][inst.K1]
 					elseif count == 3 then
-						local id1 = bit32.band(bit32.rshift(extend, 10), 0x3FF)
-						local id2 = bit32.band(bit32.rshift(extend, 0), 0x3FF)
-						stack[inst.A] = env[constants[id0 + 1]][constants[id1 + 1]][constants[id2 + 1]]
+						stack[inst.A] = env[inst.K0][inst.K1][inst.K2]
 					end
 				elseif op == 13 then --[[ GETTABLE ]]
 					stack[inst.A] = stack[inst.B][stack[inst.C]]
@@ -424,12 +477,12 @@ local function luau_load(module, env)
 				elseif op == 15 then --[[ GETTABLEKS ]]
 					pc += 1 --// adjust for aux 
 
-					local index = constants[inst.aux + 1]
+					local index = inst.K
 					stack[inst.A] = stack[inst.B][index]
 				elseif op == 16 then --[[ SETTABLEKS ]]
-					pc += 1 --// adjust for aux 
+					pc += 1 --// adjust for aux
 
-					local index = constants[inst.aux + 1]
+					local index = inst.K
 					stack[inst.B][index] = stack[inst.A]
 				elseif op == 17 then --[[ GETTABLEN ]]
 					stack[inst.A] = stack[inst.B][inst.C + 1]
@@ -450,7 +503,7 @@ local function luau_load(module, env)
 						if type == 0 then --// value
 							local upvalue = {
 								value = stack[pseudo.B],
-								index = "value", --// self reference
+								index = "value",--// self reference
 							}
 							upvalue.store = upvalue
 
@@ -480,7 +533,7 @@ local function luau_load(module, env)
 					local A = inst.A
 					local B = inst.B
 
-					local kv = constants[inst.aux + 1]
+					local kv = inst.K
 					local sb = stack[B]
 
 					stack[A + 1] = sb
@@ -577,17 +630,17 @@ local function luau_load(module, env)
 				elseif op == 38 then --[[ POW ]]
 					stack[inst.A] = stack[inst.B] ^ stack[inst.C]
 				elseif op == 39 then --[[ ADDK ]]
-					stack[inst.A] = stack[inst.B] + constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] + inst.K
 				elseif op == 40 then --[[ SUBK ]]
-					stack[inst.A] = stack[inst.B] - constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] - inst.K
 				elseif op == 41 then --[[ MULK ]]
-					stack[inst.A] = stack[inst.B] * constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] * inst.K
 				elseif op == 42 then --[[ DIVK ]]
-					stack[inst.A] = stack[inst.B] / constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] / inst.K
 				elseif op == 43 then --[[ MODK ]]
-					stack[inst.A] = stack[inst.B] % constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] % inst.K
 				elseif op == 44 then --[[ POWK ]]
-					stack[inst.A] = stack[inst.B] ^ constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] ^ inst.K
 				elseif op == 45 then --[[ AND ]]
 					local value = stack[inst.B]
 					if (not not value) == false then
@@ -607,14 +660,14 @@ local function luau_load(module, env)
 					if (not not value) == false then
 						stack[inst.A] = value
 					else
-						stack[inst.A] = constants[inst.C + 1] or false
+						stack[inst.A] = inst.K or false
 					end
 				elseif op == 48 then --[[ ORK ]]
 					local value = stack[inst.B]
 					if (not not value) == true then
 						stack[inst.A] = value
 					else
-						stack[inst.A] = constants[inst.C + 1] or false
+						stack[inst.A] = inst.K or false
 					end
 				elseif op == 49 then --[[ CONCAT ]]
 					local s = ""
@@ -633,7 +686,7 @@ local function luau_load(module, env)
 
 					stack[inst.A] = table_create(inst.aux)
 				elseif op == 54 then --[[ DUPTABLE ]]
-					local template = constants[inst.D + 1]
+					local template = inst.K
 					local serialized = {}
 					for _, id in template do
 						serialized[constants[id + 1]] = nil
@@ -655,7 +708,7 @@ local function luau_load(module, env)
 					local A = inst.A
 					local limit = stack[A]
 					if type(limit) ~= "number" then
-						local number = to_number(limit)
+						local number = tonumber(limit)
 
 						if number == nil then
 							error("invalid 'for' limit (number expected)")
@@ -666,7 +719,7 @@ local function luau_load(module, env)
 					end
 					local step = stack[A + 1]
 					if type(step) ~= "number" then
-						local number = to_number(step)
+						local number = tonumber(step)
 
 						if number == nil then
 							error("invalid 'for' step (number expected)")
@@ -677,7 +730,7 @@ local function luau_load(module, env)
 					end
 					local index = stack[A + 2]
 					if type(index) ~= "number" then
-						local number = to_number(index)
+						local number = tonumber(index)
 
 						if number == nil then
 							error("invalid 'for' index (number expected)")
@@ -768,7 +821,7 @@ local function luau_load(module, env)
 
 					table_move(varargs.list, 1, b, A, stack)
 				elseif op == 64 then --[[ DUPCLOSURE ]]
-					local newPrototype = protolist[constants[inst.D + 1] + 1] --// correct behavior would be to reuse the prototype if possible but it would not be useful here
+					local newPrototype = protolist[inst.K + 1] --// correct behavior would be to reuse the prototype if possible but it would not be useful here
 
 					local upvalues = {}
 
@@ -781,7 +834,7 @@ local function luau_load(module, env)
 						if type == 0 then --// value
 							local upvalue = {
 								value = stack[pseudo.B],
-								index = "value", --// self reference
+								index = "value",--// self reference
 							}
 							upvalue.store = upvalue
 
@@ -798,7 +851,7 @@ local function luau_load(module, env)
 				elseif op == 66 then --[[ LOADKX ]]
 					pc += 1 --// adjust for aux 
 
-					local kv = constants[inst.aux + 1]
+					local kv = inst.K
 					stack[inst.A] = kv
 				elseif op == 67 then --[[ JUMPX ]]
 					pc += inst.E
@@ -808,9 +861,9 @@ local function luau_load(module, env)
 					--[[ Handled by CLOSURE ]]
 					error("Unhandled CAPTURE")
 				elseif op == 71 then --[[ SUBRK ]]
-					stack[inst.A] = constants[inst.B + 1] - stack[inst.C]  
+					stack[inst.A] = inst.K - stack[inst.B]  
 				elseif op == 72 then --[[ DIVRK ]]
-					stack[inst.A] = constants[inst.B + 1] / stack[inst.C]  
+					stack[inst.A] = inst.K / stack[inst.B]  
 				elseif op == 73 then --[[ FASTCALL1 ]]
 					--[[ Skipped ]]
 				elseif op == 74 then --[[ FASTCALL2 ]]
@@ -821,8 +874,8 @@ local function luau_load(module, env)
 					local it = stack[inst.A]
 
 					if type(it) ~= "function" then 
-						local loopInstruction = code[pc + inst.D]
-						if generalized_iterators[loopInstruction] == nil then 
+						local loopinstruction = code[pc + inst.D]
+						if generalized_iterators[loopinstruction] == nil then 
 							--// Thanks @bmcq-0 and @memcorrupt for the spoonfeed
 							local function iterator()
 								for r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30, r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45, r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60, r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75, r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90, r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104, r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116, r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128, r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140, r141, r142, r143, r144, r145, r146, r147, r148, r149, r150, r151, r152, r153, r154, r155, r156, r157, r158, r159, r160, r161, r162, r163, r164, r165, r166, r167, r168, r169, r170, r171, r172, r173, r174, r175, r176, r177, r178, r179, r180, r181, r182, r183, r184, r185, r186, r187, r188, r189, r190, r191, r192, r193, r194, r195, r196, r197, r198, r199, r200 in it do 
@@ -832,7 +885,7 @@ local function luau_load(module, env)
 								coroutine_yield(LUA_GENERALIZED_TERMINATOR)
 							end
 
-							generalized_iterators[loopInstruction] = coroutine_create(iterator)
+							generalized_iterators[loopinstruction] = coroutine_create(iterator)
 						end
 					end
 
@@ -844,17 +897,17 @@ local function luau_load(module, env)
 						pc += 1
 					end
 				elseif op == 78 then --[[ JUMPXEQKB ]]
+					local kv = inst.K
 					local aux = inst.aux
 
-					if ((stack[inst.A] and true or false) == (bit32.band(aux, 1) == 1 and true or false) and 0 or 1) == (bit32.rshift(aux, 31)) then
+					if ((stack[inst.A] and true or false) == (kv and true or false) and 0 or 1) == (bit32.rshift(aux, 31)) then
 						pc += inst.D
 					else
 						pc += 1
 					end
 				elseif op == 79 then --[[ JUMPXEQKN ]]
 					local aux = inst.aux
-
-					local kv = constants[bit32.band(aux, 0xffffff) + 1]
+					local kv = inst.K
 
 					local A = stack[inst.A]
 					if bit32.rshift(aux, 31) == 0 then
@@ -865,8 +918,7 @@ local function luau_load(module, env)
 					end
 				elseif op == 80 then --[[ JUMPXEQKS ]]
 					local aux = inst.aux
-
-					local kv = constants[bit32.band(aux, 0xffffff) + 1]
+					local kv = inst.K
 
 					if ((kv == stack[inst.A]) and 1 or 0) ~= bit32.rshift(aux, 31) then 
 						pc += inst.D
@@ -876,7 +928,7 @@ local function luau_load(module, env)
 				elseif op == 81 then --[[ IDIV ]]
 					stack[inst.A] = stack[inst.B] // stack[inst.C]
 				elseif op == 82 then --[[ IDIVK ]]
-					stack[inst.A] = stack[inst.B] // constants[inst.C + 1]
+					stack[inst.A] = stack[inst.B] // inst.K
 				else
 					error("Unsupported Opcode: " .. inst.opname .. " op: " .. op)
 				end
@@ -903,7 +955,7 @@ local function luau_load(module, env)
 			local debugging = {pc = 0, name = "NONE"}
 			local result
 			if not FIU_DEBUGGING then --// for debugging issues
-				result = table_pack(protected_call(luau_execute, debugging, stack, proto.protos, proto.code, varargs))
+				result = table_pack(pcall(luau_execute, debugging, stack, proto.protos, proto.code, varargs))
 			else
 				result = table_pack(true, luau_execute(debugging, stack, proto.protos, proto.code, varargs))
 			end
@@ -911,7 +963,7 @@ local function luau_load(module, env)
 			if result[1] then
 				return table.unpack(result, 2, result.n)
 			else
-				error(string.format("Fiu VM Error PC: %s Opcode: %s: \n%s", debugging.pc, debugging.name, result[2]), 0)
+				error(string.format("Fiu VM Error PC: %s Opcode: %s: \n%s",debugging.pc, debugging.name, result[2]), 0)
 			end
 		end
 		return wrapped

--- a/bin/RunTests.lua
+++ b/bin/RunTests.lua
@@ -42,7 +42,7 @@ local stagingTests = {
 	"Booleans",
 	"Concat",
 	"DupTableSetList",
-	"GetImportSpecial",
+	-- "GetImportSpecial",
 	"Globals",
 	"HelloWorld",
 	"LOADN",


### PR DESCRIPTION
Added second pass when reading instructions, after constants have been defined, to replace constant table indices in instructions with direct references to the constant. Constant is held in inst.K, besides for imports, where the constants are in inst.K0, inst.K1, inst.K2 depending on the import path size.
Updated VM execute to make use of this, replacing most uses of the constants table while executing instructions.

Renamed variables and functions to use camelCase. Some variables stay the same to match the names Luau lvmload.cpp uses.

Localized buffer functions that are being used.