### PR TITLE
New benchmarks tests & `TestSuite` update

### DIFF
--- a/tests/Benchmarks/Speeds/closure.lua
+++ b/tests/Benchmarks/Speeds/closure.lua
@@ -1,0 +1,56 @@
+--!ctx Luau
+
+local source = [=[
+local iterations = 100000
+local f; f = function() end
+for _ = 1, iterations do
+	f()
+end
+]=]
+local ok, compileResult = Luau.compile(source)
+
+if not ok then
+	error(compileResult)
+end
+
+local settings = Fiu.luau_newsettings()
+
+settings.errorHandling = false
+
+local fiuEnv = {tostring = tostring}
+local fiuExecute = Fiu.luau_load(compileResult, fiuEnv, settings)
+local fiuCodeGenExecute = FiuCodeGen.luau_load(compileResult, fiuEnv, settings)
+
+local nativeExecute = loadstring(source)
+
+local fiuTime = 0
+local luauTime = 0
+local fiuCodeGenTime = 0
+
+local start = os.clock()
+local testStart = start
+nativeExecute()
+luauTime = os.clock() - start
+
+start = os.clock()
+fiuExecute()
+fiuTime = os.clock() - start
+
+start = os.clock()
+if FiuCodeGen.__codegenReady then
+	fiuCodeGenExecute()
+end
+fiuCodeGenTime = os.clock() - start
+
+local totalTime = os.clock() - testStart
+
+local results = `Closure Speed: [Luau: {math.round(luauTime * 1000000)}us] [Fiu: {math.round(fiuTime * 1000000)}us]`;
+if FiuCodeGen.__codegenReady then
+	results ..= ` [Fiu (CodeGen): {math.round(fiuCodeGenTime * 1000000)}]`;
+else
+	results ..= ` [Fiu (CodeGen): None]`;
+end
+
+results ..= ` Total Time: {math.round(totalTime * 1000000)}us`;
+
+OK(results)

--- a/tests/Benchmarks/Speeds/closure.lua
+++ b/tests/Benchmarks/Speeds/closure.lua
@@ -17,7 +17,7 @@ local settings = Fiu.luau_newsettings()
 
 settings.errorHandling = false
 
-local fiuEnv = {tostring = tostring}
+local fiuEnv = {}
 local fiuExecute = Fiu.luau_load(compileResult, fiuEnv, settings)
 local fiuCodeGenExecute = FiuCodeGen.luau_load(compileResult, fiuEnv, settings)
 

--- a/tests/Benchmarks/Speeds/table.lua
+++ b/tests/Benchmarks/Speeds/table.lua
@@ -1,0 +1,59 @@
+--!ctx Luau
+
+local source = [=[
+local iterations = 100000
+
+local T = {}
+for Idx = 1, iterations do
+	T[tostring(Idx)] = 'Id: ' .. tostring(Idx)
+end
+
+for Idx = 1, iterations do
+	T[1] = T[tostring(Idx)]
+end
+]=]
+local ok, compileResult = Luau.compile(source)
+
+if not ok then
+	error(compileResult)
+end
+
+local settings = Fiu.luau_newsettings()
+
+settings.errorHandling = false
+
+local fiuEnv = {tostring = tostring}
+local fiuExecute = Fiu.luau_load(compileResult, fiuEnv, settings)
+local fiuCodeGenExecute = FiuCodeGen.luau_load(compileResult, fiuEnv, settings)
+
+local nativeExecute = loadstring(source)
+
+local fiuTime = 0
+local luauTime = 0
+local fiuCodeGenTime = 0
+
+local start = os.clock()
+local testStart = start
+nativeExecute()
+luauTime = os.clock() - start
+
+start = os.clock()
+fiuExecute()
+fiuTime = os.clock() - start
+
+start = os.clock()
+fiuCodeGenExecute()
+fiuCodeGenTime = os.clock() - start
+
+local totalTime = os.clock() - testStart
+
+local results = `Closure Speed: [Luau: {math.round(luauTime * 1000000)}us] [Fiu: {math.round(fiuTime * 1000000)}us]`;
+if FiuCodeGen.__codegenReady then
+	results ..= ` [Fiu (CodeGen): {math.round(fiuCodeGenTime * 1000000)}]`;
+else
+	results ..= ` [Fiu (CodeGen): None]`;
+end
+
+results ..= ` Total Time: {math.round(totalTime * 1000000)}us`;
+
+OK(results)

--- a/tests/Benchmarks/Speeds/table.lua
+++ b/tests/Benchmarks/Speeds/table.lua
@@ -47,7 +47,7 @@ fiuCodeGenTime = os.clock() - start
 
 local totalTime = os.clock() - testStart
 
-local results = `Closure Speed: [Luau: {math.round(luauTime * 1000000)}us] [Fiu: {math.round(fiuTime * 1000000)}us]`;
+local results = `Set/Get Table Speed: [Luau: {math.round(luauTime * 1000000)}us] [Fiu: {math.round(fiuTime * 1000000)}us]`;
 if FiuCodeGen.__codegenReady then
 	results ..= ` [Fiu (CodeGen): {math.round(fiuCodeGenTime * 1000000)}]`;
 else

--- a/tests/Config.h
+++ b/tests/Config.h
@@ -21,6 +21,7 @@ using namespace std;
 #define COLOR_RESET "\033[1;0m"   // ANSI escape code to reset the color
 
 #define ERROR_SYMBOL (COLOR_RED "X" COLOR_RESET)
+#define WARN_SYMBOL (COLOR_YELLOW "-" COLOR_RESET)
 #define SUCCESS_SYMBOL (COLOR_GREEN "+" COLOR_RESET)
 
 #define FIU_TESTCASES map<string, vector<string>> TestCases =
@@ -141,6 +142,8 @@ FIU_TESTCASES {
 	}},
 	{"Benchmarks", {
 		// Fiu Benchmark Tests
+		"Benchmarks/Speeds/closure",
+		"Benchmarks/Speeds/table",
 		"Benchmarks/maxcstack",
 	}}
 };


### PR DESCRIPTION
- Added speed tests in benchmarks
- Added `CodeGen` to the TestSuite.
- For Luau context tests,` CodeGen` api of `Fiu` is given if compiled correctly, variables are exposed to let tests know the status of `FiuCodeGen` api.

```lua
--!ctx Luau
-- <boolean> true for `FiuCodeGen` api to be powered using CodeGen, otherwise it is interpreted, same as `Fiu` api.
FiuCodeGen.__codegenReady
```