### PR TITLE
Optimization: `GETIMPORT` constant pre-process

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -178,13 +178,20 @@ local function luau_validatesettings(luau_settings)
 	assert(type(luau_settings.useImportConstants) == "boolean", "luau_settings.useImportConstants should be a boolean")
 end
 
+local function assertImport(import, message)
+	if import == nil then
+		error(message, 0)
+	end
+	return import
+end
+
 local function resolveImportConstant(static, count, k0, k1, k2)
 	if count == 1 then
-		return static[k0]
+		return assertImport(static[k0], `Could not resolve import constant: {k0}\nMake sure the import is defined in staticEnvironment.`)
 	elseif count == 2 then
-		return static[k0][k1]
+		return assertImport(static[k0][k1], `Could not resolve import constant: {k0}.{k1}\nMake sure the import is defined in staticEnvironment.`)
 	elseif count == 3 then
-		return static[k0][k1][k2]
+		return assertImport(static[k0][k1][k2], `Could not resolve import constant: {k0}.{k1}.{k2}\nMake sure the import is defined in staticEnvironment.`)
 	end
 	return error(`Could not resolve import constant, unknown size: {count}`)
 end

--- a/Source.lua
+++ b/Source.lua
@@ -158,7 +158,9 @@ local function luau_newsettings()
 		errorHandling = true,
 		generalizedIteration = true,
 		allowProxyErrors = false,
-	}	
+		useImportConstants = false,
+		staticEnvironment = {},
+	}
 end
 
 local function luau_validatesettings(luau_settings)
@@ -172,6 +174,19 @@ local function luau_validatesettings(luau_settings)
 	assert(type(luau_settings.errorHandling) == "boolean", "luau_settings.errorHandling should be a boolean")
 	assert(type(luau_settings.generalizedIteration) == "boolean", "luau_settings.generalizedIteration should be a boolean")
 	assert(type(luau_settings.allowProxyErrors) == "boolean", "luau_settings.allowProxyErrors should be a boolean")
+	assert(type(luau_settings.staticEnvironment) == "table", "luau_settings.staticEnvironment should be a table")
+	assert(type(luau_settings.useImportConstants) == "boolean", "luau_settings.useImportConstants should be a boolean")
+end
+
+local function resolveImportConstant(static, count, k0, k1, k2)
+	if count == 1 then
+		return static[k0]
+	elseif count == 2 then
+		return static[k0][k1]
+	elseif count == 3 then
+		return static[k0][k1][k2]
+	end
+	return error(`Could not resolve import constant, unknown size: {count}`)
 end
 
 local function luau_deserialize(bytecode, luau_settings)
@@ -326,6 +341,12 @@ local function luau_deserialize(bytecode, luau_settings)
 
 				inst.K1 = k[id1 + 1]
 				inst.K2 = k[id2 + 1]
+			end
+			if luau_settings.useImportConstants then
+				inst.K = resolveImportConstant(
+					luau_settings.staticEnvironment,
+					count, inst.K0, inst.K1, inst.K2
+				)
 			end
 		elseif kmode == 5 then --// AUX boolean low 1 bit
 			inst.K = bit32_extract(inst.aux, 0, 1) == 1
@@ -642,16 +663,19 @@ local function luau_load(module, env, luau_settings)
 						end
 					end
 				elseif op == 12 then --[[ GETIMPORT ]]
-					local count = inst.KC
-					local k0 = inst.K0
-					local import = extensions[k0] or env[k0]
-
-					if count == 1 then
-						stack[inst.A] = import
-					elseif count == 2 then
-						stack[inst.A] = import[inst.K1]
-					elseif count == 3 then
-						stack[inst.A] = import[inst.K1][inst.K2]
+					if luau_settings.useImportConstants then
+						stack[inst.A] = inst.K
+					else
+						local count = inst.KC
+						local k0 = inst.K0
+						local import = extensions[k0] or env[k0]
+						if count == 1 then
+							stack[inst.A] = import
+						elseif count == 2 then
+							stack[inst.A] = import[inst.K1]
+						elseif count == 3 then
+							stack[inst.A] = import[inst.K1][inst.K2]
+						end
 					end
 
 					pc += 1 --// adjust for aux 

--- a/tests/Config.h
+++ b/tests/Config.h
@@ -142,6 +142,7 @@ FIU_TESTCASES {
 		"Specs/extensions",
 		"Specs/nativeNamecall",
 		"Specs/vectorLib",
+		"Specs/importConstants",
 	}},
 	{"Benchmarks", {
 		// Fiu Benchmark Tests

--- a/tests/Specs/importConstants.lua
+++ b/tests/Specs/importConstants.lua
@@ -1,0 +1,57 @@
+--!ctx Luau
+
+local ok, compileResult = Luau.compile([[
+local a = A
+local b = Lib.B
+local c = Lib.List.C
+
+assert(a() == "A")
+assert(b() == "Lib.B")
+assert(c() == "Lib.List.C")
+]], {
+	optimizationLevel = 2,
+	debugLevel = 2,
+	coverageLevel = 0,
+	vectorLib = nil,
+	vectorCtor = nil,
+	vectorType = nil
+})
+
+if not ok then
+	error(compileResult)
+end
+
+local settings = Fiu.luau_newsettings()
+
+local calledConstants = {}
+
+settings.useImportConstants = true
+settings.staticEnvironment = {
+	assert = assert,
+	A = function()
+		calledConstants.A = true
+		return "A"
+	end,
+	Lib = {
+		B = function()
+			calledConstants.B = true
+			return "Lib.B"
+		end,
+		List = {
+			C = function()
+				calledConstants.C = true
+				return "Lib.List.C"
+			end
+		}
+	}
+}
+
+local func, _ = Fiu.luau_load(Fiu.luau_deserialize(compileResult, settings), {}, settings)
+
+func()
+
+assert(calledConstants.A, "A was not called")
+assert(calledConstants.B, "B was not called")
+assert(calledConstants.C, "C was not called")
+
+OK()

--- a/tests/Specs/importConstants.lua
+++ b/tests/Specs/importConstants.lua
@@ -54,4 +54,11 @@ assert(calledConstants.A, "A was not called")
 assert(calledConstants.B, "B was not called")
 assert(calledConstants.C, "C was not called")
 
+settings.staticEnvironment = {}
+
+local success, message = pcall(Fiu.luau_deserialize, compileResult, settings)
+
+assert(success == false, "luau_deserialize should have errored")
+assert(MATCH(message, "Could not resolve import constant: A\nMake sure the import is defined in staticEnvironment."))
+
 OK()


### PR DESCRIPTION
Closes #31

```lua
local settings = Fiu.luau_newsettings()
settings.useImportConstants = true
settings.staticEnvironment = {
	math = math
}
```