### PR TITLE
Create `.editorconfig` and `.gitattributes`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+[*.lua]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.md]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.yml]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.cpp]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.c]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.h]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.txt]
+indent_size = 4
+end_of_line = lf
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Auto detect text files and perform LF normalization
+*.lua text=auto
+*.lua eol=lf
+*.md text=auto
+*.md eol=lf
+*.yml text=auto
+*.yml eol=lf
+*.cpp text=auto
+*.cpp eol=lf
+*.c text=auto
+*.c eol=lf
+*.h text=auto
+*.h eol=lf
+*.txt text=auto
+*.txt eol=lf


### PR DESCRIPTION
Enforce LF and UTF-8 for all files and set default tab rendering size.