### PR TITLE
fix decodeOp modifying the whole opcode value

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -327,8 +327,8 @@ local function luau_deserialize(bytecode, luau_settings)
 	end
 
 	local function readInstruction(codeList)
-		local value = luau_settings.decodeOp(readWord())
-		local opcode = bit32_band(value, 0xFF)
+		local value = readWord()
+		local opcode = bit32_band(luau_settings.decodeOp(value), 0xFF)
 
 		local opinfo = opList[opcode + 1]
 		local opname = opinfo[1]


### PR DESCRIPTION
decodeOp was modifying the whole opcode word instead of just calling it for the opcode "id"
this made my inst.D have incredibly weird values which well errored in fiu

fix found from https://github.com/shrimp-nz/medal/blob/main/luau-lifter/src/instruction.rs#L118
(only apply the encode key for the opcode and not the whole "instruction")

(i do not know have the luau bytecode technical terms)